### PR TITLE
Move prometheus.go into own package

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/bwNetFlow/consumer_prometheus/exporter"
 	kafka "github.com/bwNetFlow/kafkaconnector"
 )
 
@@ -29,7 +30,7 @@ var (
 
 // KafkaConn holds the global kafka connection
 var kafkaConn = kafka.Connector{}
-var promExporter = Exporter{}
+var promExporter = exporter.Exporter{}
 
 func main() {
 	flag.Parse()
@@ -56,7 +57,8 @@ func main() {
 	}()
 
 	// Enable Prometheus Export
-	promExporter.Initialize(":8080")
+	promExporter.Initialize()
+	promExporter.ServeEndpoints(":8080")
 
 	// disable TLS if requested
 	if *kafkaDisableTLS {


### PR DESCRIPTION
This allows it to be used as a library by other software.

Additonally some refactorings were made to allow finer grained control over
the provided endpoints and put global state into the Exporter structure.

cc @debugloop @georg-e 